### PR TITLE
Add Localization

### DIFF
--- a/src/main/resources/assets/translocator/lang/en_US.lang
+++ b/src/main/resources/assets/translocator/lang/en_US.lang
@@ -1,3 +1,4 @@
+tile.translocator.name=Translocator
 tile.translocator|0.name=Item Translocator
 tile.translocator|1.name=Liquid Translocator
 tile.craftingGrid.name=Crafting Grid


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.